### PR TITLE
add and make InverseNormal default option for transformation

### DIFF
--- a/extensions.config.yaml
+++ b/extensions.config.yaml
@@ -6,10 +6,10 @@ finalization: .finalized
 general-extensions:
   transformation:
     suffix: .transform
-    default: none
+    default: InverseNormal
     options:
       - none
-      - post.split.INT
+      - InverseNormal
   sex-specific:
     suffix: .sex-specific
     default: combined


### PR DESCRIPTION
this is because I changed construct.model.matrix.R under construct.model.matrix to accept none as no transformation and InverseNormal as inverse normal. To be compatible with previous config files, inverse normal is the default.